### PR TITLE
install python3-venv via apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD5
 RUN add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)-cran40/" --yes
 RUN apt update && apt install --no-install-recommends r-base -y
 
+## Install python3-venv
+RUN apt install -y --no-install-recommends python3-venv python3.8-venv
 
 
 ## Apache Stuff


### PR DESCRIPTION
otherwise the default python installation is pretty much useless.

In general, one should think about a methodology how to enable the users to install packages via apt. There will always be some needs for additional packages when developping. Ideally, one would do this in the `start.sh`, but as the file-system is mounted as read-only, this won't be possible. Any ideas @mitchellurgero?