### PR TITLE
change ownership of run.sh to root

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -86,5 +86,8 @@ fi
 
 chown -R www-data:www-data /app/data /run/apache2 /run/app /tmp
 
+[[ ! -f /app/data/run.sh ]] && touch /app/data/run.sh
+chown root:root /app/data/run.sh
+
 echo "==> Starting Lamp & Code stack"
 exec /usr/bin/supervisord --configuration /etc/supervisor/supervisord.conf --nodaemon -i Lamp


### PR DESCRIPTION
to provide the possibility to remove credentials

Although it's nice that one can easily add a lot of addons with cloudron, such as LDAP or postgres, it might not be desired from the server management side that the developers with access to the code-server write to the same database server as all other apps on the cloudron. this is why there should be the possibility for the server administration to remove credentials from the `env`. One way to do this, would be to use the `/app/data/run.sh` as this is sourced on startup. But then, this file should only be modified by server administrators, i.e.  people that can login as `root`. That's why I propose to change the ownership of `run.sh` to `root` on startup. An alternative would be to add another startup script, such as `/app/data/run_root.sh` and set the ownership to `root` for this file (such that the standard `www-data` user can still modify `run.sh` 