### PR TITLE
change home of www-data to /app/data/www-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,6 @@ RUN mv code-server-3.9.1-linux-amd64 code-server
 
 
 # lock www-data but allow su - www-data to work
-RUN passwd -l www-data && usermod --shell /bin/bash --home /app/data www-data
+RUN passwd -l www-data && usermod --shell /bin/bash --home /app/data/www-data www-data
 
 CMD [ "/app/code/start.sh" ]


### PR DESCRIPTION
to avoid conflicts between user and server files

the code-server always starts in the $HOME of the user (currently `/app/data`). But there are living a lot of files already that are relevant to the server but not relevant for the code that is developed with this code-server. This is why I would propose to choose a different `HOME` for the `www-data` user.